### PR TITLE
CI: fix docker build workflows

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -40,5 +40,6 @@ jobs:
           push: false
           tags: ${{ steps.meta.outputs.image }}:${{ steps.meta.outputs.version }}
           labels: runnumber=${{ github.run_id }}
+          provenance: false
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,7 +57,8 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.image }}:${{ steps.meta.outputs.version }}
           labels: runnumber=${{ github.run_id }}
-          platforms: linux/amd64,linux/arm64
+          provenance: false
+          platforms: linux/amd64
           cache-from: type=gha
           cache-to: type=gha,mode=max
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,14 +7,27 @@ on:
   push:
     branches:
       - master
-  workflow_dispatch: 
+  workflow_dispatch:
+    inputs:
+      platform:
+        description: 'Build image for'
+        required: true
+        default: 'linux/amd64'
+        type: choice
+        options:
+          - linux/amd64
+          - linux/arm64
+      tag:
+        description: 'Override image tag'
+        required: false
+        type: string
 
 env:
   IMAGE_NAME: tg-bot-full-api
 
 jobs:
 
-  push:
+  release:
     runs-on: ubuntu-latest
     permissions:
       packages: write
@@ -28,10 +41,14 @@ jobs:
         run: |
           IMAGE_ID=ghcr.io/${{ github.repository_owner }}/$IMAGE_NAME
           IMAGE_ID=$(echo $IMAGE_ID | tr '[A-Z]' '[a-z]')
+          PLATFORM="linux/amd64"
+          [ -n "${{ github.event.inputs.platform }}" ] && PLATFORM="${{ github.event.inputs.platform }}"
           VERSION=$(echo "${{ github.ref }}" | sed -e 's,.*/\(.*\),\1,')
           [[ "${{ github.ref }}" == "refs/tags/"* ]] && VERSION=$(echo $VERSION | sed -e 's/^v//')
           [ "$VERSION" == "master" ] && VERSION=latest
+          [ -n "${{ github.event.inputs.tag }}" ] && VERSION="${{ github.event.inputs.tag }}"
           echo "image=$IMAGE_ID" >> $GITHUB_OUTPUT
+          echo "platform=$PLATFORM" >> $GITHUB_OUTPUT
           echo "version=$VERSION" >> $GITHUB_OUTPUT
 
       - name: Login ghcr.io
@@ -58,7 +75,7 @@ jobs:
           tags: ${{ steps.meta.outputs.image }}:${{ steps.meta.outputs.version }}
           labels: runnumber=${{ github.run_id }}
           provenance: false
-          platforms: linux/amd64
+          platforms: ${{ steps.meta.outputs.platform }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 


### PR DESCRIPTION
This pull request includes several updates to the GitHub Actions workflows for pull requests and releases. The main changes involve adding input options for the release workflow and modifying the job configurations to handle these new inputs.

Changes to `.github/workflows/release.yml`:

* Added `platform` and `tag` inputs to the `workflow_dispatch` trigger to allow specifying the build image platform and overriding the image tag.
* Updated the `release` job to set the `PLATFORM` and `VERSION` based on the new inputs, ensuring the correct platform and version are used during the build process.
* Modified the `release` job to dynamically set the `platforms` parameter based on the `platform` input, replacing the hardcoded platforms.

Changes to `.github/workflows/pull-request.yml`:

* Added `provenance: false` to the `push` step configuration to disable provenance for the image.